### PR TITLE
Fix map scale issue

### DIFF
--- a/src/js/choropleth.js
+++ b/src/js/choropleth.js
@@ -116,7 +116,7 @@ async function countyMouseOut() {
 }
 
 function calculateExtent(data) {
-  return d3.extent((Object.values(data)).map(c => c.per_capita !== 0 ? Math.log(c.per_capita) : 0));
+  return d3.extent((Object.values(data)).filter(d => d.per_capita).map(d => Math.log(d.per_capita)));
 }
 
 async function drawLegend() {


### PR DESCRIPTION
The extent finds the min and max. The max found was zero. The exponential of 0 is 1, which is 100%, putting the upper bound of our chart at 100%.

I have no idea why this worked yesterday and all the days prior.